### PR TITLE
Log actor and qid tag

### DIFF
--- a/projects/miragesdk/src/sdk/conf.ml
+++ b/projects/miragesdk/src/sdk/conf.ml
@@ -54,9 +54,9 @@ module Client (F: Mirage_flow_lwt.S) = struct
 
   let pp_error = Capnp_rpc.Error.pp
 
-  let connect ~switch f =
+  let connect ~switch ?tags f =
     let ep = Capnp_rpc_lwt.Endpoint.of_flow ~switch (module F) f in
-    let client = Capnp_rpc_lwt.CapTP.of_endpoint ~switch ep in
+    let client = Capnp_rpc_lwt.CapTP.of_endpoint ~switch ?tags ep in
     Capnp_rpc_lwt.CapTP.bootstrap client |> Lwt.return
 
   let find t path =
@@ -220,8 +220,8 @@ module Server = struct
             )
     end
 
-    let listen ~switch service flow fd =
+    let listen ~switch ?tags service flow fd =
       let endpoint = Capnp_rpc_lwt.Endpoint.of_flow ~switch flow fd in
-      ignore (Capnp_rpc_lwt.CapTP.of_endpoint ~switch ~offer:service endpoint)
+      ignore (Capnp_rpc_lwt.CapTP.of_endpoint ~switch ?tags ~offer:service endpoint)
 
 end

--- a/projects/miragesdk/src/sdk/conf.mli
+++ b/projects/miragesdk/src/sdk/conf.mli
@@ -14,7 +14,7 @@ module Client (F: Mirage_flow_lwt.S): sig
   type t
   (** The type for client state. *)
 
-  val connect: switch:Lwt_switch.t -> F.flow -> t Lwt.t
+  val connect: switch:Lwt_switch.t -> ?tags:Logs.Tag.set -> F.flow -> t Lwt.t
   (** [connect f] connects to the flow [f]. *)
 
   val find: t -> string list -> string option Lwt.t
@@ -70,7 +70,7 @@ module Server: sig
   type 'a flow = (module Mirage_flow_lwt.S with type flow = 'a)
   (** The type for MirageOS flows. *)
 
-  val listen: switch:Lwt_switch.t -> t -> 'a flow -> 'a -> unit
+  val listen: switch:Lwt_switch.t -> ?tags:Logs.Tag.set -> t -> 'a flow -> 'a -> unit
   (** [listen ~switch s m f] exposes service [s] on the flow
       [f]. [switch] can be used to stop the server. *)
 


### PR DESCRIPTION
This should make it easier to debug RPC problems. It includes the actor (client or server) and question ID, if any.